### PR TITLE
refactor: params can be passed by env from docker

### DIFF
--- a/src_server_thinkphp/application/config.php
+++ b/src_server_thinkphp/application/config.php
@@ -19,12 +19,10 @@ return [
     // 应用Trace
     'app_trace'              => false,
   
-
     //替换自己小程序相应的信息
-    'wechat_appid'         => '小程序ID',
-    'wechat_secret'		=> '秘钥',
+    'wechat_appid'           => getenv('WECHAT_APPID') ? getenv('WECHAT_APPID') : '小程序ID',
+    'wechat_secret'		     => getenv('WECHAT_SECRET') ? getenv('WECHAT_SECRET') : '秘钥',
   
-     
     // 应用模式状态
     'app_status'             => '',
     // 是否支持多模块

--- a/src_server_thinkphp/application/database.php
+++ b/src_server_thinkphp/application/database.php
@@ -13,15 +13,15 @@ return [
     // 数据库类型
     'type'            => 'mysql',
     // 服务器地址
-    'hostname'        => '127.0.0.1',
+    'hostname'        => getenv('DB_HOST') ? getenv('DB_HOST') : '127.0.0.1',
     // 数据库名
-    'database'        => 'ncov',
+    'database'        => getenv('DB_DB') ? getenv('DB_DB') : 'ncov',
     // 用户名
-    'username'        => 'ncov',
+    'username'        => getenv('DB_USER') ? getenv('DB_USER') : 'ncov',
     // 密码
-    'password'        => 'ncov',
+    'password'        => getenv('DB_PASS') ? getenv('DB_PASS') : 'ncov',
     // 端口
-    'hostport'        => '',
+    'hostport'        => getenv('DB_PORT') ? getenv('DB_PORT') : '',
     // 连接dsn
     'dsn'             => '',
     // 数据库连接参数


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

close #2 

该 PR 的修改内容如下：

- 使小程序和数据库配置首先尝试读取系统环境变量
- Docker 启动时可以通过 docker run -d  --env WECHAT_ID=123 --env WECHAT_SECRET=456 ncov-report 来进行配置
- 目前支持的配置包含
  - WECHAT_APPID：小程序 AppID
  - WECHAT_SECRET：小程序秘钥
  - DB_HOST：数据库地址
  - DB_DB：数据库名称
  - DB_USER：数据库用户名
  - DB_PASS：数据库密码
  - DB_PORT：数据库端口